### PR TITLE
Fix wrong curseforge URL

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,7 @@
     "tr7zw"
   ],
   "contact": {
-    "homepage": "https://www.curseforge.com/members/tr7zw/projects",
+    "homepage": "https://www.curseforge.com/members/tr9zw/projects",
     "sources": "https://github.com/tr7zw"
   },
 


### PR DESCRIPTION
The mod links to https://www.curseforge.com/members/tr7zw/projects which is wrong.
This minor PR fixes this.