### PR TITLE
fix: beyblading while eating

### DIFF
--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
@@ -144,7 +144,7 @@ public class PlayerTransformer {
             last[offset] = entity.yHeadRot;
             return;
         }
-        if (Math.abs(AnimationUtil.wrapDegrees2(entity.yHeadRot)) - Math.abs(AnimationUtil.wrapDegrees2(last[offset])) > 90) {
+        if (Math.abs(AnimationUtil.wrapDegrees2(entity.yHeadRot - last[offset])) > 90f) {
             speed *= 0.9f;
         }
         last[offset + 1] = last[offset];

--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
@@ -141,22 +141,20 @@ public class PlayerTransformer {
             return;
         }
         if (timePassed > 50) { // Don't try to interpolate states older than 100ms
-            last[offset] = entity.yHeadRot;
+            last[offset] = AnimationUtil.wrapDegrees2(entity.yHeadRot);
             return;
         }
-        if (entity.yHeadRot - last[offset] > 90) {
-            speed *= 0.9f;
-        }
-        if (entity.yHeadRot - last[offset] < -90) {
+        if (Math.abs(AnimationUtil.wrapDegrees2(entity.yHeadRot)) - Math.abs(AnimationUtil.wrapDegrees2(last[offset])) > 90) {
             speed *= 0.9f;
         }
         last[offset + 1] = last[offset];
         float amount = speed;
         amount = Math.min(amount, 1);
         entity.yBodyRotO = last[offset];
-        last[offset] += (entity.yHeadRot - last[offset]) * amount;
+        last[offset] += AnimationUtil.wrapDegrees2((entity.yHeadRot - last[offset]) * amount);
         entity.yBodyRot = (last[offset]);
         // entity.yBodyRotO = entity.yBodyRot;
+
     }
 
     /**

--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
@@ -1,5 +1,6 @@
 package dev.tr7zw.notenoughanimations.logic;
 
+import dev.tr7zw.transition.mc.MathUtil;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import dev.tr7zw.notenoughanimations.NEAnimationsLoader;
@@ -151,10 +152,9 @@ public class PlayerTransformer {
         float amount = speed;
         amount = Math.min(amount, 1);
         entity.yBodyRotO = last[offset];
-        last[offset] += AnimationUtil.wrapDegrees2((entity.yHeadRot - last[offset]) * amount);
+        last[offset] = AnimationUtil.interpolateRotation2(last[offset], entity.yHeadRot, amount);
         entity.yBodyRot = (last[offset]);
         // entity.yBodyRotO = entity.yBodyRot;
-
     }
 
     /**

--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
@@ -1,6 +1,5 @@
 package dev.tr7zw.notenoughanimations.logic;
 
-import dev.tr7zw.transition.mc.MathUtil;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import dev.tr7zw.notenoughanimations.NEAnimationsLoader;

--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
@@ -141,7 +141,7 @@ public class PlayerTransformer {
             return;
         }
         if (timePassed > 50) { // Don't try to interpolate states older than 100ms
-            last[offset] = AnimationUtil.wrapDegrees2(entity.yHeadRot);
+            last[offset] = entity.yHeadRot;
             return;
         }
         if (Math.abs(AnimationUtil.wrapDegrees2(entity.yHeadRot)) - Math.abs(AnimationUtil.wrapDegrees2(last[offset])) > 90) {

--- a/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
@@ -164,7 +164,14 @@ public class AnimationUtil {
 
     public static float wrapDegrees(float angle) {
         return ((angle + MathUtil.PI) % MathUtil.TWO_PI) - MathUtil.PI;
-    }
+    }  // despite the name, this returns radians. should probably be renamed - EW
+
+    public static float wrapDegrees2(float angle) {
+        float wrapped = (angle + 180.0f) % 360.0f;
+        if (wrapped < 0) wrapped += 360.0f;
+        return wrapped - 180.0f;
+    }  // this takes in degrees and returns degrees - EW
+
 
     public static float legacyWrapDegrees(float f) {
         float g = f % 6.28318512f;

--- a/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
@@ -152,6 +152,21 @@ public class AnimationUtil {
         return wrapDegrees(wrappedStart + (wrappedEnd - wrappedStart) * amount);
     }
 
+    public static float interpolateRotation2(float start, float end, float amount) {
+        float wrappedStart = wrapDegrees2(start);
+        float wrappedEnd = wrapDegrees2(end);
+
+        float diff = wrappedEnd - wrappedStart;
+
+        if (diff > 180) {
+            wrappedEnd -= 360;
+        } else if (diff < -180) {
+            wrappedEnd += 360;
+        }
+
+        return wrapDegrees2(wrappedStart + (wrappedEnd - wrappedStart) * amount);
+    }  // this version uses the degree to degree wrap function. - EW
+
     public static float lerpAngle(float delta, float start, float end) {
         float wrappedStart = wrapDegrees(start);
         float wrappedEnd = wrapDegrees(end);


### PR DESCRIPTION
This PR fixes the beyblades eating issue outlined in #226.

Method for reproduction of the original bug outlined
- Disable "Limit Rotation Lock to FP" (allows the bug to happen in third person)
- Spin for a while
- `/tp @p ~ ~ ~ 0 0`
- Eat

In addition, this also tries to tries to fix inconsistencies in how the amount value is slightly lowered when moving the camera fast while eating.