### PR TITLE
fix: prevent `last` corruption

### DIFF
--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
@@ -60,7 +60,7 @@ public class PlayerTransformer {
                         && differentFrame) {
                     entity.yBodyRot = entity.yHeadRot;
                     entity.yBodyRotO = entity.yHeadRotO;
-                } else {
+                } else if (differentFrame) {
                     last[ENTRY_SIZE * 4] = entity.yBodyRot;
                     last[ENTRY_SIZE * 4 + 1] = entity.yBodyRotO;
                 }
@@ -153,7 +153,7 @@ public class PlayerTransformer {
         entity.yBodyRotO = last[offset];
         last[offset] = AnimationUtil.interpolateRotation2(last[offset], entity.yHeadRot, amount);
         entity.yBodyRot = (last[offset]);
-        // entity.yBodyRotO = entity.yBodyRot;
+        // entity.yBodyRotO = entity.yBodyRot;   // don't uncomment, makes everything jittery
     }
 
     /**


### PR DESCRIPTION
This PR adds a check to PlayerTransformer's updateModel method so that the `last` array only gets updated during the first run of the frame instead of constantly.

While this corruption doesn't actually happen on my main testing version (1.21.6), it does happen on older versions (1.20.1).

This PR was tested on 1.16.5, 1.20.1, and 1.21.6, with PaperDoll and FirstPersonModel.

Fixes https://github.com/tr7zw/FirstPersonModel/issues/533