### PR TITLE
fix: unbreak all 1.16, 1.18, 1.19, and 1.20 builds (whoops)

### DIFF
--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/HeldItemHandler.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/HeldItemHandler.java
@@ -119,6 +119,7 @@ public class HeldItemHandler {
             boolean mainHandCharged = AnimationUtil.isChargedCrossbow(player.getMainHandItem());
             boolean offHandCharged = AnimationUtil.isChargedCrossbow(player.getOffhandItem());
             boolean isUsingItem = player.isUsingItem();
+            //#if MC >= 12100
             if (!mainHandCharged && isUsingItem) {
                 mainHandCharged = ((float) (player.getMainHandItem().getUseDuration(player)
                         - player.getUseItemRemainingTicks())
@@ -129,6 +130,7 @@ public class HeldItemHandler {
                         - player.getUseItemRemainingTicks())
                         / (float) CrossbowItem.getChargeDuration(player.getOffhandItem(), player) >= 1.0f);
             }
+            //#endif
 
             ArmPose mainHandPose = AnimationUtil.getArmPose(player, InteractionHand.MAIN_HAND);
             ArmPose offHandPose = AnimationUtil.getArmPose(player, InteractionHand.OFF_HAND);


### PR DESCRIPTION
My last PR failed to build on any version before 1.21.

This just excludes the code from the last PR so it's 1.21 and up. I plan to revisit the code at another time to make it work on lower versions.