### PR TITLE
fix: parseItemList mistakenly hardcoded

### DIFF
--- a/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
@@ -39,7 +39,7 @@ public class AnimationUtil {
                 if (invalid != item)
                     items.add(item);
             } catch (Exception ex) {
-                NEABaseMod.LOGGER.info("Unknown item to add to the bow list: " + itemId);
+                NEABaseMod.LOGGER.info("Unknown item to add to the list: " + itemId);
             }
         }
         return items;


### PR DESCRIPTION
As the title suggests, in AnimationUtil, parseItemList was mistakenly hardcoded to only reference `NEABaseMod.config.hideItemsForTheseBows` when it's input of `list` should've been used.