### PR TITLE
fix: don't hide spears and tridents when an offhand crossbow is charged

### DIFF
--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/HeldItemHandler.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/HeldItemHandler.java
@@ -143,7 +143,8 @@ public class HeldItemHandler implements DataHolder<HeldItemHandler.HeldItemState
         }
 
         if (NEABaseMod.config.enableOffhandHiding && entity instanceof AbstractClientPlayer player
-                && !(player.getMainHandItem().getItem() instanceof ShieldItem)) {
+                && !(player.getMainHandItem().getItem() instanceof ShieldItem)
+                && !AnimationUtil.hasUsePriority(player.getMainHandItem())) { // Don't hide still usable weapons
             boolean mainHandProjectileWeapon = player.getMainHandItem().getItem() instanceof ProjectileWeaponItem;
             boolean offHandProjectileWeapon = player.getOffhandItem().getItem() instanceof ProjectileWeaponItem;
             if (!mainHandProjectileWeapon) {

--- a/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
@@ -123,6 +123,20 @@ public class AnimationUtil {
         return CrossbowItem.isCharged(item);
     }
 
+    public static boolean hasUsePriority(ItemStack itemStack) {
+        // Spears/tridents in the mainhand consume the clicks, so an offhand crossbow never
+        // gets to fire and the mainhand item stays usable
+        var useAction = itemStack.getUseAnimation();
+        // funky way of accessing the enum because it got renamed between versions
+        //? if >= 1.21.11 {
+
+        return useAction == useAction.SPEAR || useAction == useAction.TRIDENT;
+        //? } else {
+        /*
+        return useAction == useAction.SPEAR;
+        *///? }
+    }
+
     public static void applyArmTransforms(PlayerModel model, HumanoidArm arm, float pitch, float yaw, float roll) {
         ModelPart part = arm == HumanoidArm.RIGHT ? model.rightArm : model.leftArm;
         part.xRot = pitch;


### PR DESCRIPTION
Fixes #335. The hide logic now skips items with the spear or trident use animation, mirroring the existing shield exception. On older versions this also fixes the trident vanishing while readying it, since its use animation is SPEAR there.