### PR TITLE
fix angle math bugs, head snapping on ladders, and render loop allocations

### DIFF
--- a/NEAVersionless/src/main/java/dev/tr7zw/notenoughanimations/versionless/animations/BodyPart.java
+++ b/NEAVersionless/src/main/java/dev/tr7zw/notenoughanimations/versionless/animations/BodyPart.java
@@ -1,5 +1,7 @@
 package dev.tr7zw.notenoughanimations.versionless.animations;
 
 public enum BodyPart {
-    LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG, BODY, HEAD
+    LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG, BODY, HEAD;
+
+    public static final BodyPart[] VALUES = values();
 }

--- a/NEAVersionless/src/main/java/dev/tr7zw/notenoughanimations/versionless/config/Config.java
+++ b/NEAVersionless/src/main/java/dev/tr7zw/notenoughanimations/versionless/config/Config.java
@@ -11,8 +11,8 @@ import dev.tr7zw.notenoughanimations.versionless.animations.HoldUpTarget;
 
 public class Config {
 
-    public int configVersion = 10;
-    public float animationSmoothingSpeed = 0.1f;
+    public int configVersion = 11;
+    public float animationSmoothingSpeed = 0.2f;
     public Set<String> holdingItems = new HashSet<>(Arrays.asList("minecraft:clock", "minecraft:compass",
             "minecraft:torch", "minecraft:lantern", "minecraft:soul_torch", "minecraft:soul_lantern",
             "minecraft:recovery_compass", "quad-mstv-mtv:acacia_torch", "quad-mstv-mtv:bamboo_torch",

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/fullbody/FallingAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/fullbody/FallingAnimation.java
@@ -52,9 +52,12 @@ public class FallingAnimation extends BasicAnimation
         return false;
     }
 
+    private final BodyPart[] parts = new BodyPart[] { BodyPart.LEFT_ARM, BodyPart.RIGHT_ARM, BodyPart.LEFT_LEG,
+            BodyPart.RIGHT_LEG };
+
     @Override
     public BodyPart[] getBodyParts(AbstractClientPlayer entity, PlayerData data) {
-        return BodyPart.values();
+        return parts;
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/fullbody/LadderAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/fullbody/LadderAnimation.java
@@ -39,25 +39,19 @@ public class LadderAnimation extends BasicAnimation implements PoseOverwrite {
     @Override
     public boolean isValid(AbstractClientPlayer entity, PlayerData data) {
         if (entity.onClimbable() && !NMSWrapper.onGround(entity) && entity.getLastClimbablePos().isPresent()) {
-            for (Class<? extends Block> blocktype : ladderLikeBlocks) {
-                if (blocktype.isAssignableFrom(
-                        //? if >= 1.18.0 {
+            Block block =
+                    //? if >= 1.18.0 {
 
-                        GeneralUtil.getWorld().getBlockState(entity.getLastClimbablePos().get()).getBlock().getClass()))
+                    GeneralUtil.getWorld().getBlockState(entity.getLastClimbablePos().get()).getBlock();
                     //? } else {
 
-                    // entity.level.getBlockState(entity.getLastClimbablePos().get()).getBlock().getClass()))
+                    // entity.level.getBlockState(entity.getLastClimbablePos().get()).getBlock();
                     //? }
 
-                    return true;
-            }
-            return false;
+            return block instanceof LadderBlock || block instanceof TrapDoorBlock;
         }
         return false;
     }
-
-    private final Set<Class<? extends Block>> ladderLikeBlocks = new HashSet<>(
-            Arrays.asList(LadderBlock.class, TrapDoorBlock.class));
 
     private final BodyPart[] parts = new BodyPart[] { BodyPart.LEFT_ARM, BodyPart.RIGHT_ARM, BodyPart.BODY,
             BodyPart.LEFT_LEG, BodyPart.RIGHT_LEG, BodyPart.HEAD };

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/hands/ClampCrossbowAnimations.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/hands/ClampCrossbowAnimations.java
@@ -23,12 +23,19 @@ import net.minecraft.world.entity.HumanoidArm;
 
 public class ClampCrossbowAnimations extends VanillaProjectileWeaponAnimation {
 
+    private final BodyPart[] arms = new BodyPart[] { BodyPart.LEFT_ARM, BodyPart.RIGHT_ARM };
+
     @Getter
     private final EnumSet<ArmPose> twoHandedAnimations = EnumSet.of(ArmPose.CROSSBOW_HOLD, ArmPose.CROSSBOW_CHARGE);
 
     @Override
     public boolean isEnabled() {
         return NEABaseMod.config.clampCrossbowAnimations;
+    }
+
+    @Override
+    public BodyPart[] getBodyParts(AbstractClientPlayer entity, PlayerData data) {
+        return arms;
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/hands/MapHoldingAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/hands/MapHoldingAnimation.java
@@ -37,7 +37,7 @@ public class MapHoldingAnimation extends BasicAnimation {
 
     private void bind() {
         compatibleMaps.clear();
-        compatibleMaps.addAll(AnimationUtil.parseItemList(NEAnimationsMod.config.mapHolding));
+        compatibleMaps.addAll(AnimationUtil.parseItemList(NEABaseMod.config.mapHolding));
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/hands/PetAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/hands/PetAnimation.java
@@ -76,7 +76,7 @@ public class PetAnimation extends BasicAnimation {
     @Override
     public void apply(AbstractClientPlayer entity, PlayerData data, PlayerModel model, BodyPart part, float delta,
             float tickCounter) {
-        if (Math.random() < 0.005)
+        if (targetPet != null && Math.random() < 0.005)
             targetPet.handleEntityEvent((byte) 18);
         HumanoidArm arm = part == BodyPart.LEFT_ARM ? HumanoidArm.LEFT : HumanoidArm.RIGHT;
         AnimationUtil.applyArmTransforms(model, arm,

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/DeathAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/DeathAnimation.java
@@ -27,7 +27,7 @@ public class DeathAnimation extends BasicAnimation {
 
     @Override
     public BodyPart[] getBodyParts(AbstractClientPlayer entity, PlayerData data) {
-        return BodyPart.values();
+        return BodyPart.VALUES;
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/ElytraAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/ElytraAnimation.java
@@ -31,7 +31,7 @@ public class ElytraAnimation extends BasicAnimation implements PoseOverwrite {
 
     @Override
     public BodyPart[] getBodyParts(AbstractClientPlayer entity, PlayerData data) {
-        return BodyPart.values();
+        return BodyPart.VALUES;
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/RiptideAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/RiptideAnimation.java
@@ -26,7 +26,7 @@ public class RiptideAnimation extends BasicAnimation {
 
     @Override
     public BodyPart[] getBodyParts(AbstractClientPlayer entity, PlayerData data) {
-        return BodyPart.values();
+        return BodyPart.VALUES;
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/SleepAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/SleepAnimation.java
@@ -27,7 +27,7 @@ public class SleepAnimation extends BasicAnimation {
         return entity.isSleeping();
     }
 
-    private final BodyPart[] bothHands = BodyPart.values();
+    private final BodyPart[] bothHands = BodyPart.VALUES;
 
     @Override
     public BodyPart[] getBodyParts(AbstractClientPlayer entity, PlayerData data) {

--- a/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/SwimAnimation.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/animations/vanilla/SwimAnimation.java
@@ -28,7 +28,7 @@ public class SwimAnimation extends BasicAnimation {
 
     @Override
     public BodyPart[] getBodyParts(AbstractClientPlayer entity, PlayerData data) {
-        return BodyPart.values();
+        return BodyPart.VALUES;
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/AnimationProvider.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/AnimationProvider.java
@@ -54,6 +54,8 @@ public class AnimationProvider {
     private Set<BasicAnimation> basicAnimations = new HashSet<>();
     private Set<BasicAnimation> enabledBasicAnimations = new HashSet<>();
     private Set<PoseOverwrite> enabledPoseOverwrites = new HashSet<>();
+    private BasicAnimation[] enabledBasicAnimationsArray = new BasicAnimation[0];
+    private PoseOverwrite[] enabledPoseOverwritesArray = new PoseOverwrite[0];
     private boolean dumpPrios = false;
 
     public AnimationProvider() {
@@ -63,9 +65,10 @@ public class AnimationProvider {
 
     public void applyAnimations(AbstractClientPlayer entity, PlayerModel model, float delta, float swing) {
         PlayerData playerData = (PlayerData) entity;
-        int[] priorities = new int[BodyPart.values().length];
+        int[] priorities = new int[BodyPart.VALUES.length];
         BasicAnimation[] animation = new BasicAnimation[priorities.length];
-        for (BasicAnimation basicAnimation : enabledBasicAnimations) {
+        for (int j = 0; j < enabledBasicAnimationsArray.length; j++) {
+            BasicAnimation basicAnimation = enabledBasicAnimationsArray[j];
             if (basicAnimation.isValid(entity, playerData)) {
                 int prio = basicAnimation.getPriority(entity, playerData);
                 if (prio > 0) {
@@ -82,7 +85,7 @@ public class AnimationProvider {
         for (int i = 0; i < priorities.length; i++) {
             if (animation[i] != null) {
                 animation[i].prepare(entity, playerData, model, delta, swing);
-                animation[i].apply(entity, playerData, model, BodyPart.values()[i], delta, swing);
+                animation[i].apply(entity, playerData, model, BodyPart.VALUES[i], delta, swing);
             }
         }
         for (int i = 0; i < priorities.length; i++) {
@@ -93,8 +96,8 @@ public class AnimationProvider {
     }
 
     public void preUpdate(AbstractClientPlayer livingEntity, PlayerModel playerModel) {
-        for (PoseOverwrite po : enabledPoseOverwrites) {
-            po.updateState(livingEntity, (PlayerData) livingEntity, playerModel);
+        for (int i = 0; i < enabledPoseOverwritesArray.length; i++) {
+            enabledPoseOverwritesArray[i].updateState(livingEntity, (PlayerData) livingEntity, playerModel);
         }
     }
 
@@ -146,6 +149,8 @@ public class AnimationProvider {
                 }
             }
         }
+        enabledBasicAnimationsArray = enabledBasicAnimations.toArray(new BasicAnimation[0]);
+        enabledPoseOverwritesArray = enabledPoseOverwrites.toArray(new PoseOverwrite[0]);
         if (dumpPrios) {
             List<BasicAnimation> list = new ArrayList<>(basicAnimations);
             list.sort((a, b) -> Integer.compare(a.getPriority(null, null), b.getPriority(null, null)));

--- a/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/logic/PlayerTransformer.java
@@ -151,6 +151,9 @@ public class PlayerTransformer {
         }
         if (timePassed > 50) { // Don't try to interpolate states older than 100ms
             last[offset] = entity.yHeadRot;
+            last[offset + 1] = entity.yHeadRotO;
+            entity.yBodyRot = entity.yHeadRot;
+            entity.yBodyRotO = entity.yHeadRotO;
             return;
         }
         if (Math.abs(AnimationUtil.wrapDegrees2(entity.yHeadRot - last[offset])) > 90f) {

--- a/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
+++ b/src/main/java/dev/tr7zw/notenoughanimations/util/AnimationUtil.java
@@ -179,12 +179,9 @@ public class AnimationUtil {
     }
 
     public static void minMaxHeadRotation(Player livingEntity, PlayerModel model) {
-        float value = legacyWrapDegrees(model.head.yRot);
-        float min = legacyWrapDegrees(model.body.yRot - MathUtil.HALF_PI);
-        float max = legacyWrapDegrees(model.body.yRot + MathUtil.HALF_PI);
-        value = Math.min(value, max);
-        value = Math.max(value, min);
-        setHeadYRot(model, value);
+        float diff = wrapDegrees(model.head.yRot - model.body.yRot);
+        diff = Mth.clamp(diff, -MathUtil.HALF_PI, MathUtil.HALF_PI);
+        setHeadYRot(model, model.body.yRot + diff);
     }
 
     public static void setHeadYRot(PlayerModel model, float value) {
@@ -229,14 +226,16 @@ public class AnimationUtil {
         float wrappedStart = wrapDegrees(start);
         float wrappedEnd = wrapDegrees(end);
 
-        float difference = wrappedEnd - wrappedStart;
-        float shortestPath = ((difference + MathUtil.PI) % MathUtil.TWO_PI) - MathUtil.PI;
+        float shortestPath = wrapDegrees(wrappedEnd - wrappedStart);
 
         return wrapDegrees(wrappedStart + shortestPath * delta);
     }
 
     public static float wrapDegrees(float angle) {
-        return ((angle + MathUtil.PI) % MathUtil.TWO_PI) - MathUtil.PI;
+        float wrapped = (angle + MathUtil.PI) % MathUtil.TWO_PI;
+        if (wrapped < 0)
+            wrapped += MathUtil.TWO_PI;
+        return wrapped - MathUtil.PI;
     } // despite the name, this returns radians. should probably be renamed - EW
 
     public static float wrapDegrees2(float angle) {


### PR DESCRIPTION
- **Fixed angle wrapping and modular arithmetic in `AnimationUtil`:**
  - Java's `%` operator computes remainders rather than true modular arithmetic, returning negative values for negative inputs (e.g. `(-4.0 + PI) % TWO_PI` produces a negative result). Subtracting `PI` left negative angles completely unwrapped outside `[-PI, PI]`, which broke angle interpolation. I added a check to wrap negative values back into range and updated `lerpAngle` to calculate the shortest path using the wrapped delta.
  - In `minMaxHeadRotation`, the method previously wrapped `min` and `max` absolute bounds individually before clamping. When facing South (`body.yRot = PI`), `min` evaluated to `PI/2` while `max` wrapped to `-PI/2`. Because `min > max`, the standard `Math.min`/`Math.max` clamping inverted and snapped the player's head yaw by over 100 degrees when climbing South-facing ladders. I changed this to calculate the relative angle `wrapDegrees(head.yRot - body.yRot)`, clamp that delta to `[-HALF_PI, HALF_PI]`, and apply it relative to the body.

- **Fixed stale yaw interpolation states on tick resets in `PlayerTransformer`:**
  - When `timePassed > 50` (such as after a lag spike or when a player re-enters render distance), `interpolateYawBodyHead` returned early after only updating `last[offset] = entity.yHeadRot`. It left `last[offset + 1]`, `entity.yBodyRot`, and `entity.yBodyRotO` uninitialized or holding stale data. On subsequent frames within the same tick, `entity.yBodyRotO` was restored from the old value in `last[offset + 1]`, causing visible snapping and jitter. I updated it to properly initialize both current and previous yaw fields when the timer expires.

- **Fixed config version mismatch in `Config.java`:**
  - `Config.java` had `configVersion` initialized to `10`, but `ConfigUpgrader` has a migration step for `configVersion <= 10` that bumps the version to `11` and sets `animationSmoothingSpeed = 0.2f`. When a player generated a fresh config, the second launch detected version 10 and ran the upgrader, silently overwriting any custom smoothing speed they had set. I bumped the default `configVersion` to `11` and updated the default smoothing speed to `0.2f` to match.

- **Restricted target body parts for `FallingAnimation` and `ClampCrossbowAnimations`:**
  - `FallingAnimation` returned `BodyPart.values()` (all body parts) at priority 400, but its `apply` method only transforms the arms and legs. This unnecessarily claimed priority over `BODY` and `HEAD`, blocking other valid animations without applying any changes. I restricted it to an array containing only the four limbs.
  - `ClampCrossbowAnimations` inherited `getBodyParts` from `VanillaProjectileWeaponAnimation`, which includes `BodyPart.BODY` at priority 3200. Because this animation only clamps arm pitch, claiming `BODY` blocked legitimate body rotations (like `ActionRotationLockAnimation`). I overrode `getBodyParts` to return only the left and right arms.

- **Added null check in `PetAnimation`:**
  - Added a `targetPet != null` check before calling `targetPet.handleEntityEvent((byte) 18)` in `PetAnimation.apply()` to prevent potential `NullPointerException`s if the target entity state changes between validation and rendering.

- **Standardized config access in `MapHoldingAnimation`:**
  - Changed `NEAnimationsMod.config.mapHolding` to `NEABaseMod.config.mapHolding` in `MapHoldingAnimation.bind()` to stay consistent with the rest of the codebase and avoid relying on loader-generated class references.

- **Eliminated render loop allocations and reflection overhead:**
  - Added a cached `BodyPart.VALUES` constant in `BodyPart.java` and used it across `DeathAnimation`, `ElytraAnimation`, `RiptideAnimation`, `SleepAnimation`, `SwimAnimation`, and `AnimationProvider`. Calling `.values()` inside per-frame render methods clones a new array every call, causing unnecessary GC pressure.
  - Swapped `AnimationProvider`'s `enabledBasicAnimations` and `enabledPoseOverwrites` loops from `HashSet` iteration to cached flat arrays and indexed `for` loops, removing iterator allocations on every render tick for every player.
  - Replaced the reflective `Class.isAssignableFrom` loop over `ladderLikeBlocks` in `LadderAnimation.isValid` with direct `instanceof LadderBlock || block instanceof TrapDoorBlock` checks, which compile to direct bytecode instructions and drop the collection iteration overhead.